### PR TITLE
Add GROWI Docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@
 - [Pomerium](https://www.pomerium.io) - Pomerium is the [open-source](https://github.com/pomerium/pomerium) identity-aware access proxy.
 - [Wasabi Wallet](https://docs.wasabiwallet.io) – An archive of knowledge about the open-source, non-custodial and privacy-focused Bitcoin wallet for desktop.
 - [kriry开发者网络](https://dev.kriry.com/) -  kriry开发者网络 (kriry developer net).
+- [GROWI Docs](https://docs.growi.org/) - [Open Source](https://github.com/weseek/growi) Markdown x Wiki. Real-time preview on left and right screens is possible.
 
 ### Enterprise Usage
 


### PR DESCRIPTION
GROWI documentation site developed by a WESEEK inc.
Although it is not added to the company, it is developed as OSS, so please add a site.

* https://docs.growi.org
