### PR TITLE
Link to Remote Work Encyclopedia vuepress site

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@
 - [Java 全栈知识体系](https://www.pdai.tech/) - Java 全栈知识体系 (Java full stack knowledge system).
 - [MeiliSearch](https://docs.meilisearch.com/) - [Open Source](https://github.com/meilisearch/MeiliSearch) instant search engine
 - [DBKangaroo](https://dbkangaroo.github.io/) - Database admin and management tool for popular DBMS
+- [Remote Work Encyclopedia](https://www.remoteworkencyclopedia.com) - [Open Source](https://github.com/moonlightwork/remote-work-encyclopedia) guide to remote work
 
 ### Enterprise Usage
 


### PR DESCRIPTION
 [Remote Work Encyclopedia](https://www.remoteworkencyclopedia.com) - [Open Source](https://github.com/moonlightwork/remote-work-encyclopedia) guide to remote work

