### PR TITLE
feat: add vuepress-theme-succinct

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@
 - [vuepress-theme-britecore](https://github.com/z3by/vuepress-theme-britecore) - 🤩Vuepress documentation theme using BriteCore design system. [Demo](https://vp-britecore.z3by.com/)
 - [vuepress-theme-terminal](https://github.com/jsmith/vuepress-theme-terminal) - 💻 A portfolio theme modeled as a terminal - [Preview](https://jsmith.github.io/vuepress-theme-terminal)
 - [vuepress-theme-ting](https://github.com/Chenyating/vuepress-theme-ting) - :frog: :cactus: 小清新风格-A simple and fresh style of vuepress theme. [Demo](https://chenyating.github.io/)
-
+- [vuepress-theme-succinct](https://github.com/Microflash/vuepress-theme-succinct) - Vuepress theme with support for web-fonts and light and dark themes. [Demo](https://mflash.dev/vuepress-theme-succinct/)
 
 ## Projects Using VuePress
 


### PR DESCRIPTION
Vuepress theme with support for web-fonts and dark and light themes

- **Demo**: https://mflash.dev/vuepress-theme-succinct/
- **Repo**: https://github.com/Microflash/vuepress-theme-succinct