### PR TITLE
feat: add vuepress-plugin-redirect-frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [vuepress-plugin-element-ui](https://github.com/lq782655835/vuepress-plugin-element-ui) - ✨ extend elementui base on markdown-it-container
 - [vuepress-plugin-auto-sidebar](https://github.com/shanyuhai123/vuepress-plugin-auto-sidebar) - A vuepress plugin to automatically generate sidebars
 - [vuepress-plugin-smartlook](https://github.com/webkitty/vuepress-plugin-smartlook) - A vuepress plugin integrate [Smartlook](https://smartlook.com) recording & analytics
+- [vuepress-plugin-redirect-frontmatter](https://github.com/ttskch/vuepress-plugin-redirect-frontmatter) - 🎉VuePress plugin to handle redirection via frontmatter
 
 ## Themes
 


### PR DESCRIPTION
A plugin to handle redirection via frontmatter like following.

```
---
permalink: /current-permalink
redirectFrom: /old-permalink
---
```

```
---
permalink: /current-permalink
redirectFrom:
  - /old-permalink1
  - /old-permalink2
  - /old-permalink3
---
```