### PR TITLE
feat: add vuepress-plugin-meilisearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [vuepress-plugin-element-ui](https://github.com/lq782655835/vuepress-plugin-element-ui) - ✨ extend elementui base on markdown-it-container
 - [vuepress-plugin-auto-sidebar](https://github.com/shanyuhai123/vuepress-plugin-auto-sidebar) - A vuepress plugin to automatically generate sidebars
 - [vuepress-plugin-smartlook](https://github.com/webkitty/vuepress-plugin-smartlook) - A vuepress plugin integrate [Smartlook](https://smartlook.com) recording & analytics
+- [vuepress-plugin-meilisearch](https://github.com/meilisearch/vuepress-plugin-meilisearch) - Integrate a relevant an powerful search bar using [MeiliSearch](https://docs.meilisearch.com/)!
 
 ## Themes
 


### PR DESCRIPTION
Add [vuepress-plugin-meilisearch](https://github.com/meilisearch/vuepress-plugin-meilisearch) to the list.

This plugin adds a relevant search bar to your Vuepress project using MeiliSearch:

<img width="529" alt="vuepress-searchbar-example" src="https://user-images.githubusercontent.com/20380692/82026431-07984500-9693-11ea-9a2a-a9b7e1efcde8.png">

The MeiliSearch repository: https://github.com/meilisearch/MeiliSearch
The MeiliSearch documentation (using Vuepress 😇): https://docs.meilisearch.com/